### PR TITLE
Shebang line added, php is now executed ... minor logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project builds upon earlier single-script approaches to OPNsense high avail
 **Iterative Development**: [lavacano's enhanced versions](https://gist.github.com/lavacano/a678e65d31df9bec344e572461ed3e10) expanded on the original concept with improved error handling, additional service management, and better logging capabilities. These iterations identified key pain points and reliability issues in production environments.
 
 **Current Solution**: This multi-script architecture represents a complete redesign addressing the limitations discovered in single-script approaches:
+
 - **Separation of Concerns**: Distinct scripts for different phases (boot enforcement, live failover, route management)
 - **Production Hardening**: Comprehensive error handling, circuit breakers, and failure tracking
 - **Operational Excellence**: Structured logging, dry-run testing, and configuration validation
@@ -32,15 +33,18 @@ The evolution from single-script to multi-script architecture reflects lessons l
 ## 📋 Prerequisites
 
 ### Hardware Requirements
+
 - Two identical OPNsense firewalls
 - Dedicated sync interface between firewalls
 - Shared network segments for WAN and LAN
 - **Recommended**: Configure WAN interfaces with identical MAC addresses for seamless failover
 
 ### OPNsense Configuration
+
 Before installing the scripts, configure your firewalls:
 
 #### Primary Firewall
+
 1. Go to **System → High Availability → Settings**
    - Enable HA by checking "Synchronize States"
    - Set the Synchronize Interface (dedicated SYNC interface)
@@ -50,11 +54,13 @@ Before installing the scripts, configure your firewalls:
    - Create tunable: `net.inet.carp.preempt` = `1`
 
 #### Secondary Firewall
+
 1. Configure HA Sync settings pointing to primary firewall
-2. Go to **Interfaces → Virtual IPs → Settings**
+2. Go to **System → High Availability → Settings**
    - Check "Disable Preemptive Mode"
 
 #### Both Firewalls
+
 1. Set up CARP VIPs on WAN and LAN interfaces
    - Use unique VHID for each interface
    - Primary: advskew = 0, Secondary: advskew = 100
@@ -80,13 +86,13 @@ mkdir -p /usr/local/etc/rc.d
 
 Copy the following files to both firewalls:
 
-| File | Location | Purpose |
-|------|----------|---------|
-| `ha_failover.conf` | `/usr/local/etc/` | Central configuration |
-| `validate_ha_config.php` | `/usr/local/etc/` | Configuration validator |
-| `10-failover.php` | `/usr/local/etc/rc.syshook.d/carp/` | Main failover logic |
-| `98-ha_set_routes.php` | `/usr/local/etc/rc.syshook.d/` | Route management |
-| `99-ha_passive_enforcer.sh` | `/usr/local/etc/rc.d/` | Boot-time enforcer |
+| File                        | Location                            | Purpose                 |
+| --------------------------- | ----------------------------------- | ----------------------- |
+| `ha_failover.conf`          | `/usr/local/etc/`                   | Central configuration   |
+| `validate_ha_config.php`    | `/usr/local/etc/`                   | Configuration validator |
+| `10-failover.php`           | `/usr/local/etc/rc.syshook.d/carp/` | Main failover logic     |
+| `98-ha_set_routes.php`      | `/usr/local/etc/rc.syshook.d/`      | Route management        |
+| `99-ha_passive_enforcer.sh` | `/usr/local/etc/rc.d/`              | Boot-time enforcer      |
 
 ### Step 3: Set Permissions
 
@@ -112,6 +118,7 @@ echo 'ha_passive_enforcer_enable="YES"' >> /etc/rc.conf.local
 Edit `/usr/local/etc/ha_failover.conf` for your environment:
 
 #### Static IP Configuration
+
 ```json
 {
   "interfaces": {
@@ -129,8 +136,13 @@ Edit `/usr/local/etc/ha_failover.conf` for your environment:
 ```
 
 #### DHCP Configuration
+
 ```json
 {
+  "interfaces": {
+    "wan_key": "wan",
+    "tunnel_key": "opt1"
+  },
   "network": {
     "wan_mode": "dhcp",
     "wan_gateway_name": "WAN_DHCP_GW"
@@ -138,9 +150,33 @@ Edit `/usr/local/etc/ha_failover.conf` for your environment:
 }
 ```
 
+#### PPPoE Configuration
+
+```json
+{
+  "interfaces": {
+    "wan_key": "wan",
+    "tunnel_key": "opt1"
+  },
+  "network": {
+    "wan_mode": "pppoe",
+    "wan_gateway_name": "WAN_GW"
+  }
+}
+```
+
+#### For IPv6-less Setups
+
+Remove these keys from the configuration:
+
+- `tunnel_key`
+- `tunnel_gateway_name`
+- `target_v6`
+
 ### Key Configuration Sections
 
 #### Health Check Configuration
+
 ```json
 "health_check": {
   "local_target": "192.168.1.1",
@@ -152,6 +188,20 @@ Edit `/usr/local/etc/ha_failover.conf` for your environment:
 ```
 
 #### Service Management
+
+If you use Free Range Routing then add tit as core service.
+
+```json
+"ha_core_services": [
+  {
+    "name": "frr",
+    "pid_file": "/var/run/frr/frr.pid",
+    "shutdown_timeout": 20
+  }
+```
+
+Change the DHCP and DNS, if you dont use ISC DHCPv4 Server or Unbound DNS. Add other services that also need to stop in BACKUP mode.
+
 ```json
 "ha_controlled_services": [
   {
@@ -166,21 +216,49 @@ Edit `/usr/local/etc/ha_failover.conf` for your environment:
 ]
 ```
 
+#### Timeouts
+
+```json
+"timeouts": {
+  "master_transition_delay": 20,
+  "event_cooldown_period": 600,
+  "passive_enforcer_delay": 20,
+  "route_settle_delay": 3,
+  "lock_wait_timeout": 90,
+  "health_check_retries": 3,
+  "health_check_retry_delay": 5,
+  "service_verify_timeout": 15
+}
+```
+
+| Timeout                    | Min | Max  | Default |
+| -------------------------- | --- | ---- | ------- |
+| `master_transition_delay`  | 0   | 300  | 20      |
+| `event_cooldown_period"`   | 30  | 3600 | 600     |
+| `passive_enforcer_delay`   |     |      | 20      |
+| `route_settle_delay`       | 0   | 60   | 2       |
+| `lock_wait_timeout`        | 10  | 300  | 60      |
+| `health_check_retries`     | 1   | 5    | 3       |
+| `health_check_retry_delay` | 1   | 20   | 5       |
+| `service_verify_timeout`   | 5   | 60   | 15      |
+
 ## 🧪 Testing
 
 ### Validate Configuration
+
 ```bash
 php /usr/local/etc/validate_ha_config.php
 ```
 
 ### Dry Run Testing
+
 Test failover logic without making changes:
 
 ```bash
 # Simulate MASTER transition
 php /usr/local/etc/rc.syshook.d/carp/10-failover.php carp MASTER dry-run
 
-# Simulate BACKUP transition  
+# Simulate BACKUP transition
 php /usr/local/etc/rc.syshook.d/carp/10-failover.php carp BACKUP dry-run
 
 # Test boot enforcer
@@ -188,6 +266,7 @@ sh /usr/local/etc/rc.d/99-ha_passive_enforcer.sh dry-run
 ```
 
 ### Live Testing
+
 1. **Boot Test**: Reboot secondary firewall, verify it stays in BACKUP state
 2. **Failover Test**: Put primary in maintenance mode, verify secondary becomes MASTER
 3. **Failback Test**: Remove maintenance mode, verify primary reclaims MASTER
@@ -195,18 +274,21 @@ sh /usr/local/etc/rc.d/99-ha_passive_enforcer.sh dry-run
 ## 📊 Monitoring
 
 ### Log Locations
-- **Failover Events**: `/var/log/system.log` (search for `ha_failover`)
+
+- **Failover Events**: `/var/log/system/latest.log` (search for `ha_failover`)
 - **Boot Enforcer**: `/var/log/ha_enforcer.log`
 - **CARP Status**: **Lobby → Dashboard → CARP**
 
 ### Log Format
+
 All logs use structured JSON format:
+
 ```json
 {
   "timestamp": "2024-01-15T10:30:00+00:00",
   "event": "master_transition_complete",
   "pid": 12345,
-  "context": {"transition_time": 25}
+  "context": { "transition_time": 25 }
 }
 ```
 
@@ -215,20 +297,24 @@ All logs use structured JSON format:
 ### Common Issues
 
 **Split-brain condition detected**
+
 - Check CARP sync interface connectivity
 - Verify sync interface configuration matches on both nodes
 
 **Services not starting/stopping**
+
 - Verify service names in configuration match OPNsense service names
 - Check PID file paths are correct
 - Review service-specific logs
 
 **Health checks failing**
+
 - Verify target IPs are reachable
 - Check ping timeouts are appropriate for your network
 - Review external connectivity requirements
 
 ### Debug Commands
+
 ```bash
 # Check CARP status
 ifconfig | grep carp
@@ -237,10 +323,10 @@ ifconfig | grep carp
 netstat -rn
 
 # Check service status
-service status <service_name>
+service <service_name> status
 
 # Manual service control
-/usr/local/etc/rc.syshook.d/carp/10-failover.php carp MASTER
+php /usr/local/etc/rc.syshook.d/carp/10-failover.php carp MASTER
 ```
 
 ## 🔒 Security Considerations
@@ -282,6 +368,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ## 🆘 Support
 
 For issues and questions:
+
 1. Check the troubleshooting section
 2. Review log files for error details
 3. Open an issue with configuration and log excerpts

--- a/scripts/10-failover.php
+++ b/scripts/10-failover.php
@@ -532,14 +532,14 @@ final class FailoverManager
 
         $local_ok = !$this->settings->localHealthCheckTarget;
         if ($this->settings->localHealthCheckTarget) {
-            if (mwexecf('/sbin/ping -c 1 -W 1 ' . escapeshellarg($this->settings->localHealthCheckTarget), true) === 0) {
+            if (mwexecfm('/sbin/ping -c 1 -W 1 ' . escapeshellarg($this->settings->localHealthCheckTarget)) === 0) {
                 $local_ok = true;
             }
         }
 
         $external_v4_ok = false;
         foreach ($this->settings->healthCheckTargetsV4 as $target) {
-            if (mwexecf('/sbin/ping -c 1 -W ' . escapeshellarg((string)$this->settings->pingTimeout) . ' ' . escapeshellarg($target), true) === 0) {
+            if (mwexecfm('/sbin/ping -c 1 -W ' . escapeshellarg((string)$this->settings->pingTimeout) . ' ' . escapeshellarg($target)) === 0) {
                 $external_v4_ok = true;
                 break;
             }
@@ -551,7 +551,7 @@ final class FailoverManager
                 $this->structuredLog('health_check_warn', ['reason' => 'no_ipv6_on_tunnel', 'interface' => $this->settings->tunnelInterfaceKey], LOG_WARNING);
             } else {
                 foreach ($this->settings->healthCheckTargetsV6 as $target) {
-                    if (mwexecf("ping6 -c 1 -W " . escapeshellarg((string)$this->settings->pingTimeout) . " " . escapeshellarg($target), true) === 0) {
+                    if (mwexecfm("ping6 -c 1 -W " . escapeshellarg((string)$this->settings->pingTimeout) . " " . escapeshellarg($target)) === 0) {
                         $external_v6_ok = true;
                         break;
                     }

--- a/scripts/10-failover.php
+++ b/scripts/10-failover.php
@@ -532,14 +532,14 @@ final class FailoverManager
 
         $local_ok = !$this->settings->localHealthCheckTarget;
         if ($this->settings->localHealthCheckTarget) {
-            if (mwexec('/sbin/ping -c 1 -W 1 ' . escapeshellarg($this->settings->localHealthCheckTarget), true) === 0) {
+            if (mwexecf('/sbin/ping -c 1 -W 1 ' . escapeshellarg($this->settings->localHealthCheckTarget), true) === 0) {
                 $local_ok = true;
             }
         }
 
         $external_v4_ok = false;
         foreach ($this->settings->healthCheckTargetsV4 as $target) {
-            if (mwexec('/sbin/ping -c 1 -W ' . escapeshellarg((string)$this->settings->pingTimeout) . ' ' . escapeshellarg($target), true) === 0) {
+            if (mwexecf('/sbin/ping -c 1 -W ' . escapeshellarg((string)$this->settings->pingTimeout) . ' ' . escapeshellarg($target), true) === 0) {
                 $external_v4_ok = true;
                 break;
             }
@@ -551,7 +551,7 @@ final class FailoverManager
                 $this->structuredLog('health_check_warn', ['reason' => 'no_ipv6_on_tunnel', 'interface' => $this->settings->tunnelInterfaceKey], LOG_WARNING);
             } else {
                 foreach ($this->settings->healthCheckTargetsV6 as $target) {
-                    if (mwexec("ping6 -c 1 -W " . escapeshellarg((string)$this->settings->pingTimeout) . " " . escapeshellarg($target), true) === 0) {
+                    if (mwexecf("ping6 -c 1 -W " . escapeshellarg((string)$this->settings->pingTimeout) . " " . escapeshellarg($target), true) === 0) {
                         $external_v6_ok = true;
                         break;
                     }

--- a/scripts/10-failover.php
+++ b/scripts/10-failover.php
@@ -1,3 +1,4 @@
+#!/usr/local/bin/php
 <?php
 
 /*
@@ -238,7 +239,7 @@ final class FailoverManager
             return 1;
         }
 
-        $this->structuredLog('state_change_detected', ['from' => $scriptState->value, 'to' => $eventStatus->value]);
+        $this->structuredLog('state_change_detected', ['from' => $scriptState->value, 'to' => $eventStatus->value], LOG_NOTICE);
         $success = match ($eventStatus) {
             CarpStatus::MASTER => $this->handleMasterTransition(),
             CarpStatus::BACKUP => $this->handleBackupTransition(),
@@ -306,8 +307,10 @@ final class FailoverManager
             $configArray['interfaces'][$this->settings->wanInterfaceKey]['ipaddr'] = 'dhcp';
             unset($configArray['interfaces'][$this->settings->wanInterfaceKey]['subnet']);
         } else {
-            $configArray['interfaces'][$this->settings->wanInterfaceKey]['ipaddr'] = $this->settings->wanIpv4;
-            $configArray['interfaces'][$this->settings->wanInterfaceKey]['subnet'] = $this->settings->wanSubnetV4;
+            if ($this->wanMode === 'static') {
+                $configArray['interfaces'][$this->settings->wanInterfaceKey]['ipaddr'] = $this->settings->wanIpv4;
+                $configArray['interfaces'][$this->settings->wanInterfaceKey]['subnet'] = $this->settings->wanSubnetV4;
+            }
         }
         $configArray['interfaces'][$this->settings->wanInterfaceKey]['enable'] = true;
         $configArray['interfaces'][$this->settings->wanInterfaceKey]['gateway'] = $this->settings->wanGatewayName;
@@ -340,7 +343,7 @@ final class FailoverManager
              return false;
         }
 
-        $this->structuredLog('master_transition_complete');
+        $this->structuredLog('master_transition_complete', [], LOG_NOTICE);
         return true;
     }
 
@@ -369,7 +372,7 @@ final class FailoverManager
 
         if (!$this->applyConfigurationWithRetry('HA Failover: Deactivating to BACKUP state', $configArray)) return false;
 
-        $this->structuredLog('backup_transition_complete');
+        $this->structuredLog('backup_transition_complete', [], LOG_NOTICE);
         return true;
     }
 
@@ -503,7 +506,7 @@ final class FailoverManager
                 return true;
             }
             if ($i < $this->settings->healthCheckRetries) {
-                $this->structuredLog('health_check_retry', ['attempt' => $i, 'delay' => $this->settings->healthCheckRetryDelay], LOG_NOTICE);
+                $this->structuredLog('health_check_retry', ['attempt' => $i, 'delay' => $this->settings->healthCheckRetryDelay]);
                 sleep($this->settings->healthCheckRetryDelay);
             }
         }
@@ -560,7 +563,7 @@ final class FailoverManager
 
         $results = ['local_ok' => $local_ok, 'external_v4_ok' => $external_v4_ok, 'external_v6_ok' => $external_v6_ok];
         $this->structuredLog('health_check_results', $results, LOG_INFO);
-        
+
         if ($this->settings->requireExternalConnectivity) {
             if ($local_ok && $external_ok) return true;
         } else {
@@ -710,6 +713,7 @@ final class FailoverManager
     private function structuredLog(string $event, array $context = [], int $priority = LOG_INFO): void
     {
         $logData = [
+            'ha_failover' => '10-failover.php',
             'timestamp' => date('c'),
             'event' => $event,
             'pid' => getmypid(),

--- a/scripts/98-ha_set_routes.php
+++ b/scripts/98-ha_set_routes.php
@@ -10,8 +10,8 @@ use OPNsense\Core\Backend;
 
 function log_enforcer($message, $is_error = true)
 {
-    $level = $is_error ? "ERROR" : "INFO";
-    logger("ha_passive_enforcer: ${level} - " . $message);
+    $level = $is_error ? LOG_ERR : LOG_NOTICE;
+    syslog($level, "ha_failover 98-ha_set_routes.php: " . $message);
 }
 
 function verify_route_installed($gateway_ip, $family): bool
@@ -19,7 +19,7 @@ function verify_route_installed($gateway_ip, $family): bool
     $be = new Backend();
     $routes_json = $be->configdRun("interface routes list -n json");
     $routes = json_decode($routes_json, true) ?? [];
-    
+
     foreach ($routes as $route) {
         if ($route['destination'] === 'default' &&
             $route['gateway'] === $gateway_ip &&
@@ -73,7 +73,7 @@ try {
     if (json_last_error() !== JSON_ERROR_NONE) {
         throw new \Exception("Failed to decode ha_failover.conf JSON: " . json_last_error_msg());
     }
-    
+
     $settle_delay = $ha_conf['timeouts']['route_settle_delay'] ?? 2;
     $failover_gateways = $ha_conf['failover_gateways'] ?? [
         'ipv4' => 'LAN_FAILOVER_GW',
@@ -83,7 +83,7 @@ try {
     $gw_v6_name = $failover_gateways['ipv6'];
 
     $config = load_config_from_file("/conf/config.xml");
-    $gws = $config["gateways"]["gateway_item"] ?? [];
+    $gws = $config["OPNsense"]["Gateways"]["gateway_item"] ?? [];
     $gw_v4 = null; $gw_v4_if_friendly = null;
     $gw_v6 = null; $gw_v6_if_friendly = null;
 
@@ -91,10 +91,12 @@ try {
         if (isset($gw["name"]) && $gw["name"] === $gw_v4_name) {
             $gw_v4 = $gw["gateway"];
             $gw_v4_if_friendly = $gw["interface"];
+            log_enforcer("Found failover gateway '{$gw_v4_name}' with IP {$gw_v4} on interface {$gw_v4_if_friendly}.", false);
         }
         if (isset($gw["name"]) && $gw["name"] === $gw_v6_name) {
             $gw_v6 = $gw["gateway"];
             $gw_v6_if_friendly = $gw["interface"];
+            log_enforcer("Found failover gateway '{$gw_v6_name}' with IP {$gw_v6} on interface {$gw_v6_if_friendly}.", false);
         }
     }
 
@@ -106,7 +108,7 @@ try {
     $ifdetails = legacy_interfaces_details();
     $v4_ok = set_and_verify_route($gw_v4, $gw_v4_if_friendly, $settle_delay, $ifdetails);
     $v6_ok = set_and_verify_route($gw_v6, $gw_v6_if_friendly, $settle_delay, $ifdetails);
-    
+
     $all_ok = $v4_ok && $v6_ok;
     exit($all_ok ? 0 : 1);
 

--- a/scripts/99-ha_passive_enforcer.sh
+++ b/scripts/99-ha_passive_enforcer.sh
@@ -32,11 +32,13 @@ trap cleanup EXIT INT TERM
 # Helper function to stop a list of services defined by a JQ filter
 stop_service_list() {
     local service_list_jq_filter=$1
-    echo "$service_list_jq_filter" | jq -r '.[]? | "\(.name):\(.pid_file):\(.shutdown_timeout // 10)"' "$HA_CONF" | while IFS=: read -r service_name pid_file shutdown_timeout; do
+    local array_field=$2
+    # log "Processing service list with filter: $service_list_jq_filter and array field: $array_field"
+    echo "$service_list_jq_filter" | echo "$array_field" | while IFS=: read -r service_name pid_file shutdown_timeout; do
         if [ -f "$pid_file" ] && PID=$(cat "$pid_file" 2>/dev/null) && [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
             log "Stopping '$service_name' (PID: $PID, Timeout: ${shutdown_timeout}s)..."
             [ $IS_DRY_RUN -eq 0 ] && kill "$PID"
-            
+
             shutdown_wait=$shutdown_timeout
             while [ $shutdown_wait -gt 0 ]; do
                 if [ $IS_DRY_RUN -eq 1 ] || ! kill -0 "$PID" 2>/dev/null; then
@@ -82,13 +84,14 @@ ha_passive_enforcer_start()
     log "HA configuration file is valid."
     # ----------------------------------------
 
-    LOCK_TIMEOUT=$(jq -r '.timeouts.lock_wait_timeout // 60' "$HA_CONF" 2>/dev/null)
-    exec 200>"$LOCK_FILE"
-    if ! flock -n -w "$LOCK_TIMEOUT" 200; then
-        log "ERROR: Could not acquire lock after ${LOCK_TIMEOUT}s. Aborting."
-        exit 1;
-    fi
-    echo $$ >&200
+    # Locking doesn't work reliable. Sometimes it works and sometimes not. So we disable it for now and rely on the fact that this script is only called by the HA system and not manually.
+    # LOCK_TIMEOUT=$(jq -r '.timeouts.lock_wait_timeout // 60' "$HA_CONF" 2>/dev/null)
+    # exec 200>"$LOCK_FILE"
+    # if ! flock -n -w "$LOCK_TIMEOUT" 200; then
+    #     log "ERROR: Could not acquire lock after ${LOCK_TIMEOUT}s. Aborting."
+    #     exit 1;
+    # fi
+    # echo $$ >&200
 
     if ! grep -q "<disablepreempt>" /conf/config.xml; then
         log "PRIMARY node detected. No action needed."
@@ -96,16 +99,16 @@ ha_passive_enforcer_start()
     fi
 
     log "BACKUP node detected. Enforcing passive state."
-    
+
     DELAY=$(jq -r '.timeouts.passive_enforcer_delay // 20' "$HA_CONF" 2>/dev/null)
     log "Waiting for ${DELAY}s for system to settle..."
     [ $IS_DRY_RUN -eq 0 ] && sleep "$DELAY"
 
     log "Stopping standard HA-controlled services..."
-    stop_service_list "$(jq -c '.ha_controlled_services' "$HA_CONF" 2>/dev/null)"
+    stop_service_list "$(jq -c '.ha_controlled_services' "$HA_CONF")" "$(jq -r '.ha_controlled_services[]? | "\(.name):\(.pid_file):\(.shutdown_timeout // 10)"' "$HA_CONF")"
 
     log "Stopping core HA-controlled services..."
-    stop_service_list "$(jq -c '.ha_core_services' "$HA_CONF" 2>/dev/null)"
+    stop_service_list "$(jq -c '.ha_core_services' "$HA_CONF")" "$(jq -r '.ha_core_services[]? | "\(.name):\(.pid_file):\(.shutdown_timeout // 10)"' "$HA_CONF")"
 
     log "Setting default routes via dedicated script..."
     if [ $IS_DRY_RUN -eq 1 ]; then


### PR DESCRIPTION
Made changes to some logs, wondering why I didn't see them in system.log.
Added the line for PHP-CLI-Interpreter, and it worked.

- #!/usr/local/bin/php added
- made sure that wanInterfaceKey stays untouched if not wanMode === static
- log level changed to see logs for master/backup transition
- added 'ha_failover' => '10-failover.php' to logdata to easily see if a log was written by this or any other script